### PR TITLE
Add CONTRIBUTING.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Agent guidelines
+
+Instructions for AI coding agents (Claude Code, Copilot, Cursor, etc.) working in this repo.
+
+## Project overview
+
+<!-- TODO: one paragraph describing what this repo does -->
+
+## Local setup
+
+<!-- TODO: mirror the setup steps from CONTRIBUTING.md -->
+
+```bash
+# Example
+git clone git@github.com:redis-performance/<repo>.git
+cd <repo>
+```
+
+## Branch naming
+
+Same as human contributors: `<type>/<short-description>` (e.g. `fix/off-by-one-in-pipeline`).
+
+## Coding standards
+
+- Match the style already in the file you are editing.
+- Prefer clear, minimal changes over large refactors unless explicitly asked.
+- Do not add comments that describe *what* the code does — only add comments when the *why* is non-obvious.
+- Do not introduce new dependencies without checking with the maintainer.
+
+## Running tests
+
+<!-- TODO: exact command to run tests -->
+
+```bash
+# Example
+make test
+```
+
+Always run tests before declaring a task complete.
+
+## How to submit changes
+
+1. Create a branch: `git checkout -b <type>/<description>`.
+2. Commit with a clear message focused on *why*, not *what*.
+3. Open a pull request against `main`.
+4. Do **not** push directly to `main`.
+
+## What to avoid
+
+- Do not reformat files unrelated to your change.
+- Do not remove error handling or tests.
+- Do not commit secrets, credentials, or large binary files.
+- Do not amend published commits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,17 +4,18 @@ Instructions for AI coding agents (Claude Code, Copilot, Cursor, etc.) working i
 
 ## Project overview
 
-<!-- TODO: one paragraph describing what this repo does -->
+`redis_exporter` is a Prometheus exporter for Redis metrics. It connects to one or more Redis instances and exposes their `INFO` statistics, keyspace data, and optional per-key metrics as a Prometheus `/metrics` endpoint (default port 9121). It supports Redis 2.x, 3.x, 4.x, 5.x, 6.x, and 7.x, as well as Redis Cluster, Redis Sentinel, KeyDB, and Tile38. The exporter is written in Go and uses the `gomodule/redigo` client library and the `prometheus/client_golang` instrumentation library.
 
 ## Local setup
 
-<!-- TODO: mirror the setup steps from CONTRIBUTING.md -->
-
 ```bash
-# Example
-git clone git@github.com:redis-performance/<repo>.git
-cd <repo>
+git clone git@github.com:redis-performance/redis_exporter.git
+cd redis_exporter
+go build .
+./redis_exporter --version
 ```
+
+Go 1.20 or later is required. Dependencies are managed with Go modules and are fetched automatically by `go build`.
 
 ## Branch naming
 
@@ -29,11 +30,24 @@ Same as human contributors: `<type>/<short-description>` (e.g. `fix/off-by-one-i
 
 ## Running tests
 
-<!-- TODO: exact command to run tests -->
+The test suite requires live Redis instances. Spin them up with Docker Compose before running tests:
 
 ```bash
-# Example
-make test
+# Start all required Redis containers
+docker-compose -f contrib/docker-compose-for-tests.yml up -d
+
+# Run the full suite (inside the test container with all URIs configured)
+make docker-test
+
+# Or run tests directly when the Redis instances are already reachable:
+go test -v -covermode=atomic -cover -race -coverprofile=coverage.txt -p 1 ./...
+```
+
+For static checks:
+
+```bash
+go vet ./...
+make checks   # gofmt compliance check
 ```
 
 Always run tests before declaring a task complete.
@@ -42,8 +56,8 @@ Always run tests before declaring a task complete.
 
 1. Create a branch: `git checkout -b <type>/<description>`.
 2. Commit with a clear message focused on *why*, not *what*.
-3. Open a pull request against `main`.
-4. Do **not** push directly to `main`.
+3. Open a pull request against `master`.
+4. Do **not** push directly to `master`.
 
 ## What to avoid
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+We treat this repo as "Open Source" within Redis: anyone who clears the bar below is welcome to contribute.
+
+## Local setup
+
+<!-- TODO: fill in repo-specific setup steps -->
+
+```bash
+# Example — replace with actual steps
+git clone git@github.com:redis-performance/<repo>.git
+cd <repo>
+# install dependencies, build, etc.
+```
+
+## Branch naming
+
+```
+<type>/<short-description>
+```
+
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+
+Example: `feat/add-pipeline-mode`
+
+## Coding standards
+
+- Keep changes focused; one logical change per PR.
+- Follow the conventions already present in the codebase (formatting, naming, error handling).
+- No dead code, no commented-out blocks.
+
+## Submitting changes
+
+1. Fork or create a branch from `main`.
+2. Make your changes with clear, atomic commits.
+3. Open a pull request against `main` with a descriptive title and summary.
+4. Address review comments promptly; force-push to the same branch to update.
+
+## Testing
+
+- All new behaviour must be covered by tests.
+- Existing tests must pass: run the test suite locally before opening a PR.
+- Coverage should not decrease.
+
+<!-- TODO: add the exact test command for this repo -->
+
+## Review process
+
+- At least one maintainer approval is required before merge.
+- CI must be green.
+- Maintainers may request changes or close PRs that don't meet the bar — this is normal and not personal.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,8 +58,7 @@ go test -v -covermode=atomic -cover -race -coverprofile=coverage.txt -p 1 ./...
 Static checks and formatting:
 
 ```bash
-go vet ./...
-make checks   # verifies gofmt compliance
+make checks   # runs go vet and verifies gofmt compliance
 make lint     # runs golangci-lint (requires golangci-lint installed)
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,14 @@ We treat this repo as "Open Source" within Redis: anyone who clears the bar belo
 
 ## Local setup
 
-<!-- TODO: fill in repo-specific setup steps -->
-
 ```bash
-# Example — replace with actual steps
-git clone git@github.com:redis-performance/<repo>.git
-cd <repo>
-# install dependencies, build, etc.
+git clone git@github.com:redis-performance/redis_exporter.git
+cd redis_exporter
+go build .
+./redis_exporter --version
 ```
+
+Go 1.20 or later is required. Dependencies are managed with Go modules; running `go build .` will fetch them automatically.
 
 ## Branch naming
 
@@ -31,9 +31,9 @@ Example: `feat/add-pipeline-mode`
 
 ## Submitting changes
 
-1. Fork or create a branch from `main`.
+1. Fork or create a branch from `master`.
 2. Make your changes with clear, atomic commits.
-3. Open a pull request against `main` with a descriptive title and summary.
+3. Open a pull request against `master` with a descriptive title and summary.
 4. Address review comments promptly; force-push to the same branch to update.
 
 ## Testing
@@ -42,7 +42,26 @@ Example: `feat/add-pipeline-mode`
 - Existing tests must pass: run the test suite locally before opening a PR.
 - Coverage should not decrease.
 
-<!-- TODO: add the exact test command for this repo -->
+The test suite requires running Redis instances (multiple versions). The easiest way to spin them up is via Docker Compose:
+
+```bash
+# Start all Redis containers used by the tests
+docker-compose -f contrib/docker-compose-for-tests.yml up -d
+
+# Run the full test suite (inside the container that has all URIs pre-set)
+make docker-test
+
+# Or, if the Redis instances are already reachable, run tests directly:
+go test -v -covermode=atomic -cover -race -coverprofile=coverage.txt -p 1 ./...
+```
+
+Static checks and formatting:
+
+```bash
+go vet ./...
+make checks   # verifies gofmt compliance
+make lint     # runs golangci-lint (requires golangci-lint installed)
+```
 
 ## Review process
 


### PR DESCRIPTION
## Summary
- Adds baseline `CONTRIBUTING.md` (project setup, coding standards, PR workflow, testing, review process)
- Adds `AGENTS.md` with AI agent guidelines

Part of the Redis "Open Source within Redis" initiative — ensuring every repo in the org has clear contribution and agent guidelines to enable cross-team contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)