### PR TITLE
docs: add CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Prometheus Redis Metrics Exporter
 
 [![Build Status](https://drone-github.21zoo.com/api/badges/oliver006/redis_exporter/status.svg)](https://drone-github.21zoo.com/oliver006/redis_exporter)
- [![Coverage Status](https://coveralls.io/repos/github/oliver006/redis_exporter/badge.svg?branch=master)](https://coveralls.io/github/oliver006/redis_exporter?branch=master) [![codecov](https://codecov.io/gh/oliver006/redis_exporter/branch/master/graph/badge.svg)](https://codecov.io/gh/oliver006/redis_exporter) [![docker_pulls](https://img.shields.io/docker/pulls/oliver006/redis_exporter.svg)](https://img.shields.io/docker/pulls/oliver006/redis_exporter.svg) [![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+ [![Coverage Status](https://coveralls.io/repos/github/oliver006/redis_exporter/badge.svg?branch=master)](https://coveralls.io/github/oliver006/redis_exporter?branch=master) [![codecov](https://codecov.io/gh/oliver006/redis_exporter/branch/master/graph/badge.svg)](https://codecov.io/gh/oliver006/redis_exporter) [![docker_pulls](https://img.shields.io/docker/pulls/oliver006/redis_exporter.svg)](https://img.shields.io/docker/pulls/oliver006/redis_exporter.svg) [![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua) [![CI](https://github.com/redis-performance/redis_exporter/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/redis-performance/redis_exporter/actions/workflows/codeql-analysis.yml)
 
 Prometheus exporter for Redis metrics.\
 Supports Redis 2.x, 3.x, 4.x, 5.x, 6.x, and 7.x


### PR DESCRIPTION
## Summary

- Appends a CI status badge (`codeql-analysis.yml`) to the existing badge line in README.md

## Badge added

[![CI](https://github.com/redis-performance/redis_exporter/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/redis-performance/redis_exporter/actions/workflows/codeql-analysis.yml)

## Test plan
- [ ] Badge renders correctly on the README
- [ ] Link points to the correct Actions workflow page

🤖 Generated with [Claude Code](https://claude.com/claude-code)